### PR TITLE
Add basic business entities and endpoints

### DIFF
--- a/src/main/java/com/ferrisys/common/dto/ClientDTO.java
+++ b/src/main/java/com/ferrisys/common/dto/ClientDTO.java
@@ -1,0 +1,21 @@
+package com.ferrisys.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ClientDTO {
+    private Integer id;
+    private String name;
+    private String email;
+    private Integer status;
+}

--- a/src/main/java/com/ferrisys/common/dto/ProviderDTO.java
+++ b/src/main/java/com/ferrisys/common/dto/ProviderDTO.java
@@ -1,0 +1,19 @@
+package com.ferrisys.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProviderDTO {
+    private Integer id;
+    private String name;
+    private String contact;
+    private Integer status;
+}

--- a/src/main/java/com/ferrisys/common/dto/PurchaseDTO.java
+++ b/src/main/java/com/ferrisys/common/dto/PurchaseDTO.java
@@ -1,0 +1,22 @@
+package com.ferrisys.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PurchaseDTO {
+    private Integer id;
+    private Integer providerId;
+    private String description;
+    private BigDecimal total;
+    private Integer status;
+}

--- a/src/main/java/com/ferrisys/common/dto/QuoteDTO.java
+++ b/src/main/java/com/ferrisys/common/dto/QuoteDTO.java
@@ -1,0 +1,22 @@
+package com.ferrisys.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class QuoteDTO {
+    private Integer id;
+    private Integer clientId;
+    private String description;
+    private BigDecimal total;
+    private Integer status;
+}

--- a/src/main/java/com/ferrisys/common/entity/business/Client.java
+++ b/src/main/java/com/ferrisys/common/entity/business/Client.java
@@ -1,0 +1,30 @@
+package com.ferrisys.common.entity.business;
+
+import com.ferrisys.common.audit.Auditable;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "bus_client")
+public class Client extends Auditable implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column
+    private String email;
+
+    @Column(nullable = false)
+    private Integer status;
+}

--- a/src/main/java/com/ferrisys/common/entity/business/Provider.java
+++ b/src/main/java/com/ferrisys/common/entity/business/Provider.java
@@ -1,0 +1,30 @@
+package com.ferrisys.common.entity.business;
+
+import com.ferrisys.common.audit.Auditable;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "bus_provider")
+public class Provider extends Auditable implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column
+    private String contact;
+
+    @Column(nullable = false)
+    private Integer status;
+}

--- a/src/main/java/com/ferrisys/common/entity/business/Purchase.java
+++ b/src/main/java/com/ferrisys/common/entity/business/Purchase.java
@@ -1,0 +1,35 @@
+package com.ferrisys.common.entity.business;
+
+import com.ferrisys.common.audit.Auditable;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "bus_purchase")
+public class Purchase extends Auditable implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "provider_id", nullable = false)
+    private Provider provider;
+
+    @Column
+    private String description;
+
+    @Column
+    private BigDecimal total;
+
+    @Column(nullable = false)
+    private Integer status;
+}

--- a/src/main/java/com/ferrisys/common/entity/business/Quote.java
+++ b/src/main/java/com/ferrisys/common/entity/business/Quote.java
@@ -1,0 +1,35 @@
+package com.ferrisys.common.entity.business;
+
+import com.ferrisys.common.audit.Auditable;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "bus_quote")
+public class Quote extends Auditable implements Serializable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne
+    @JoinColumn(name = "client_id", nullable = false)
+    private Client client;
+
+    @Column
+    private String description;
+
+    @Column
+    private BigDecimal total;
+
+    @Column(nullable = false)
+    private Integer status;
+}

--- a/src/main/java/com/ferrisys/controller/ClientController.java
+++ b/src/main/java/com/ferrisys/controller/ClientController.java
@@ -1,0 +1,31 @@
+package com.ferrisys.controller;
+
+import com.ferrisys.common.dto.ClientDTO;
+import com.ferrisys.service.business.ClientService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/clients")
+@RequiredArgsConstructor
+public class ClientController {
+
+    private final ClientService clientService;
+
+    @PostMapping("/save")
+    public void save(@RequestBody ClientDTO dto) {
+        clientService.saveOrUpdate(dto);
+    }
+
+    @PostMapping("/disable")
+    public void disable(@RequestParam Integer id) {
+        clientService.disable(id);
+    }
+
+    @GetMapping("/list")
+    public List<ClientDTO> list() {
+        return clientService.list();
+    }
+}

--- a/src/main/java/com/ferrisys/controller/ProviderController.java
+++ b/src/main/java/com/ferrisys/controller/ProviderController.java
@@ -1,0 +1,31 @@
+package com.ferrisys.controller;
+
+import com.ferrisys.common.dto.ProviderDTO;
+import com.ferrisys.service.business.ProviderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/providers")
+@RequiredArgsConstructor
+public class ProviderController {
+
+    private final ProviderService providerService;
+
+    @PostMapping("/save")
+    public void save(@RequestBody ProviderDTO dto) {
+        providerService.saveOrUpdate(dto);
+    }
+
+    @PostMapping("/disable")
+    public void disable(@RequestParam Integer id) {
+        providerService.disable(id);
+    }
+
+    @GetMapping("/list")
+    public List<ProviderDTO> list() {
+        return providerService.list();
+    }
+}

--- a/src/main/java/com/ferrisys/controller/PurchaseController.java
+++ b/src/main/java/com/ferrisys/controller/PurchaseController.java
@@ -1,0 +1,31 @@
+package com.ferrisys.controller;
+
+import com.ferrisys.common.dto.PurchaseDTO;
+import com.ferrisys.service.business.PurchaseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/purchases")
+@RequiredArgsConstructor
+public class PurchaseController {
+
+    private final PurchaseService purchaseService;
+
+    @PostMapping("/save")
+    public void save(@RequestBody PurchaseDTO dto) {
+        purchaseService.saveOrUpdate(dto);
+    }
+
+    @PostMapping("/disable")
+    public void disable(@RequestParam Integer id) {
+        purchaseService.disable(id);
+    }
+
+    @GetMapping("/list")
+    public List<PurchaseDTO> list() {
+        return purchaseService.list();
+    }
+}

--- a/src/main/java/com/ferrisys/controller/QuoteController.java
+++ b/src/main/java/com/ferrisys/controller/QuoteController.java
@@ -1,0 +1,31 @@
+package com.ferrisys.controller;
+
+import com.ferrisys.common.dto.QuoteDTO;
+import com.ferrisys.service.business.QuoteService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/v1/quotes")
+@RequiredArgsConstructor
+public class QuoteController {
+
+    private final QuoteService quoteService;
+
+    @PostMapping("/save")
+    public void save(@RequestBody QuoteDTO dto) {
+        quoteService.saveOrUpdate(dto);
+    }
+
+    @PostMapping("/disable")
+    public void disable(@RequestParam Integer id) {
+        quoteService.disable(id);
+    }
+
+    @GetMapping("/list")
+    public List<QuoteDTO> list() {
+        return quoteService.list();
+    }
+}

--- a/src/main/java/com/ferrisys/repository/ClientRepository.java
+++ b/src/main/java/com/ferrisys/repository/ClientRepository.java
@@ -1,0 +1,9 @@
+package com.ferrisys.repository;
+
+import com.ferrisys.common.entity.business.Client;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ClientRepository extends JpaRepository<Client, Integer> {
+}

--- a/src/main/java/com/ferrisys/repository/ProviderRepository.java
+++ b/src/main/java/com/ferrisys/repository/ProviderRepository.java
@@ -1,0 +1,9 @@
+package com.ferrisys.repository;
+
+import com.ferrisys.common.entity.business.Provider;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProviderRepository extends JpaRepository<Provider, Integer> {
+}

--- a/src/main/java/com/ferrisys/repository/PurchaseRepository.java
+++ b/src/main/java/com/ferrisys/repository/PurchaseRepository.java
@@ -1,0 +1,9 @@
+package com.ferrisys.repository;
+
+import com.ferrisys.common.entity.business.Purchase;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PurchaseRepository extends JpaRepository<Purchase, Integer> {
+}

--- a/src/main/java/com/ferrisys/repository/QuoteRepository.java
+++ b/src/main/java/com/ferrisys/repository/QuoteRepository.java
@@ -1,0 +1,9 @@
+package com.ferrisys.repository;
+
+import com.ferrisys.common.entity.business.Quote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuoteRepository extends JpaRepository<Quote, Integer> {
+}

--- a/src/main/java/com/ferrisys/service/business/ClientService.java
+++ b/src/main/java/com/ferrisys/service/business/ClientService.java
@@ -1,0 +1,11 @@
+package com.ferrisys.service.business;
+
+import com.ferrisys.common.dto.ClientDTO;
+
+import java.util.List;
+
+public interface ClientService {
+    void saveOrUpdate(ClientDTO dto);
+    void disable(Integer id);
+    List<ClientDTO> list();
+}

--- a/src/main/java/com/ferrisys/service/business/ProviderService.java
+++ b/src/main/java/com/ferrisys/service/business/ProviderService.java
@@ -1,0 +1,11 @@
+package com.ferrisys.service.business;
+
+import com.ferrisys.common.dto.ProviderDTO;
+
+import java.util.List;
+
+public interface ProviderService {
+    void saveOrUpdate(ProviderDTO dto);
+    void disable(Integer id);
+    List<ProviderDTO> list();
+}

--- a/src/main/java/com/ferrisys/service/business/PurchaseService.java
+++ b/src/main/java/com/ferrisys/service/business/PurchaseService.java
@@ -1,0 +1,11 @@
+package com.ferrisys.service.business;
+
+import com.ferrisys.common.dto.PurchaseDTO;
+
+import java.util.List;
+
+public interface PurchaseService {
+    void saveOrUpdate(PurchaseDTO dto);
+    void disable(Integer id);
+    List<PurchaseDTO> list();
+}

--- a/src/main/java/com/ferrisys/service/business/QuoteService.java
+++ b/src/main/java/com/ferrisys/service/business/QuoteService.java
@@ -1,0 +1,11 @@
+package com.ferrisys.service.business;
+
+import com.ferrisys.common.dto.QuoteDTO;
+
+import java.util.List;
+
+public interface QuoteService {
+    void saveOrUpdate(QuoteDTO dto);
+    void disable(Integer id);
+    List<QuoteDTO> list();
+}

--- a/src/main/java/com/ferrisys/service/business/impl/ClientServiceImpl.java
+++ b/src/main/java/com/ferrisys/service/business/impl/ClientServiceImpl.java
@@ -1,0 +1,46 @@
+package com.ferrisys.service.business.impl;
+
+import com.ferrisys.common.dto.ClientDTO;
+import com.ferrisys.common.entity.business.Client;
+import com.ferrisys.repository.ClientRepository;
+import com.ferrisys.service.business.ClientService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ClientServiceImpl implements ClientService {
+
+    private final ClientRepository clientRepository;
+
+    @Override
+    @Transactional
+    public void saveOrUpdate(ClientDTO dto) {
+        Client client = dto.getId() != null
+                ? clientRepository.findById(dto.getId()).orElse(new Client())
+                : new Client();
+        client.setName(dto.getName());
+        client.setEmail(dto.getEmail());
+        client.setStatus(dto.getStatus() != null ? dto.getStatus() : 1);
+        clientRepository.save(client);
+    }
+
+    @Override
+    @Transactional
+    public void disable(Integer id) {
+        Client client = clientRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Cliente no encontrado"));
+        client.setStatus(0);
+        clientRepository.save(client);
+    }
+
+    @Override
+    public List<ClientDTO> list() {
+        return clientRepository.findAll().stream()
+                .map(c -> new ClientDTO(c.getId(), c.getName(), c.getEmail(), c.getStatus()))
+                .toList();
+    }
+}

--- a/src/main/java/com/ferrisys/service/business/impl/ProviderServiceImpl.java
+++ b/src/main/java/com/ferrisys/service/business/impl/ProviderServiceImpl.java
@@ -1,0 +1,46 @@
+package com.ferrisys.service.business.impl;
+
+import com.ferrisys.common.dto.ProviderDTO;
+import com.ferrisys.common.entity.business.Provider;
+import com.ferrisys.repository.ProviderRepository;
+import com.ferrisys.service.business.ProviderService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProviderServiceImpl implements ProviderService {
+
+    private final ProviderRepository providerRepository;
+
+    @Override
+    @Transactional
+    public void saveOrUpdate(ProviderDTO dto) {
+        Provider provider = dto.getId() != null
+                ? providerRepository.findById(dto.getId()).orElse(new Provider())
+                : new Provider();
+        provider.setName(dto.getName());
+        provider.setContact(dto.getContact());
+        provider.setStatus(dto.getStatus() != null ? dto.getStatus() : 1);
+        providerRepository.save(provider);
+    }
+
+    @Override
+    @Transactional
+    public void disable(Integer id) {
+        Provider provider = providerRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Proveedor no encontrado"));
+        provider.setStatus(0);
+        providerRepository.save(provider);
+    }
+
+    @Override
+    public List<ProviderDTO> list() {
+        return providerRepository.findAll().stream()
+                .map(p -> new ProviderDTO(p.getId(), p.getName(), p.getContact(), p.getStatus()))
+                .toList();
+    }
+}

--- a/src/main/java/com/ferrisys/service/business/impl/PurchaseServiceImpl.java
+++ b/src/main/java/com/ferrisys/service/business/impl/PurchaseServiceImpl.java
@@ -1,0 +1,58 @@
+package com.ferrisys.service.business.impl;
+
+import com.ferrisys.common.dto.PurchaseDTO;
+import com.ferrisys.common.entity.business.Provider;
+import com.ferrisys.common.entity.business.Purchase;
+import com.ferrisys.repository.ProviderRepository;
+import com.ferrisys.repository.PurchaseRepository;
+import com.ferrisys.service.business.PurchaseService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PurchaseServiceImpl implements PurchaseService {
+
+    private final PurchaseRepository purchaseRepository;
+    private final ProviderRepository providerRepository;
+
+    @Override
+    @Transactional
+    public void saveOrUpdate(PurchaseDTO dto) {
+        Purchase purchase = dto.getId() != null
+                ? purchaseRepository.findById(dto.getId()).orElse(new Purchase())
+                : new Purchase();
+        Provider provider = providerRepository.findById(dto.getProviderId())
+                .orElseThrow(() -> new RuntimeException("Proveedor no encontrado"));
+        purchase.setProvider(provider);
+        purchase.setDescription(dto.getDescription());
+        purchase.setTotal(dto.getTotal());
+        purchase.setStatus(dto.getStatus() != null ? dto.getStatus() : 1);
+        purchaseRepository.save(purchase);
+    }
+
+    @Override
+    @Transactional
+    public void disable(Integer id) {
+        Purchase purchase = purchaseRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Compra no encontrada"));
+        purchase.setStatus(0);
+        purchaseRepository.save(purchase);
+    }
+
+    @Override
+    public List<PurchaseDTO> list() {
+        return purchaseRepository.findAll().stream()
+                .map(p -> PurchaseDTO.builder()
+                        .id(p.getId())
+                        .providerId(p.getProvider().getId())
+                        .description(p.getDescription())
+                        .total(p.getTotal())
+                        .status(p.getStatus())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/ferrisys/service/business/impl/QuoteServiceImpl.java
+++ b/src/main/java/com/ferrisys/service/business/impl/QuoteServiceImpl.java
@@ -1,0 +1,58 @@
+package com.ferrisys.service.business.impl;
+
+import com.ferrisys.common.dto.QuoteDTO;
+import com.ferrisys.common.entity.business.Client;
+import com.ferrisys.common.entity.business.Quote;
+import com.ferrisys.repository.ClientRepository;
+import com.ferrisys.repository.QuoteRepository;
+import com.ferrisys.service.business.QuoteService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QuoteServiceImpl implements QuoteService {
+
+    private final QuoteRepository quoteRepository;
+    private final ClientRepository clientRepository;
+
+    @Override
+    @Transactional
+    public void saveOrUpdate(QuoteDTO dto) {
+        Quote quote = dto.getId() != null
+                ? quoteRepository.findById(dto.getId()).orElse(new Quote())
+                : new Quote();
+        Client client = clientRepository.findById(dto.getClientId())
+                .orElseThrow(() -> new RuntimeException("Cliente no encontrado"));
+        quote.setClient(client);
+        quote.setDescription(dto.getDescription());
+        quote.setTotal(dto.getTotal());
+        quote.setStatus(dto.getStatus() != null ? dto.getStatus() : 1);
+        quoteRepository.save(quote);
+    }
+
+    @Override
+    @Transactional
+    public void disable(Integer id) {
+        Quote quote = quoteRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Cotización no encontrada"));
+        quote.setStatus(0);
+        quoteRepository.save(quote);
+    }
+
+    @Override
+    public List<QuoteDTO> list() {
+        return quoteRepository.findAll().stream()
+                .map(q -> QuoteDTO.builder()
+                        .id(q.getId())
+                        .clientId(q.getClient().getId())
+                        .description(q.getDescription())
+                        .total(q.getTotal())
+                        .status(q.getStatus())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/resources/db/migration/V2__insert_initial_data.sql
+++ b/src/main/resources/db/migration/V2__insert_initial_data.sql
@@ -5,3 +5,19 @@ INSERT INTO user_status (status_id, name, description) VALUES
 INSERT INTO auth_role (id, name, description, status) VALUES
                                                           (1, 'USER', 'Rol por defecto para usuarios', 1),
                                                           (2, 'ADMIN', 'Administrador del sistema', 1);
+
+-- default modules
+INSERT INTO auth_module (id, name, description, status) VALUES
+    (1, 'INVENTORY', 'Inventory Module', 1),
+    (2, 'CLIENT', 'Client Module', 1),
+    (3, 'PROVIDER', 'Provider Module', 1),
+    (4, 'QUOTE', 'Quote Module', 1),
+    (5, 'PURCHASE', 'Purchase Module', 1);
+
+-- assign modules to admin role
+INSERT INTO auth_role_module (auth_role_id, auth_module_id, status) VALUES
+    (2, 1, 1),
+    (2, 2, 1),
+    (2, 3, 1),
+    (2, 4, 1),
+    (2, 5, 1);

--- a/src/main/resources/db/migration/V3__business_tables.sql
+++ b/src/main/resources/db/migration/V3__business_tables.sql
@@ -1,0 +1,29 @@
+CREATE TABLE IF NOT EXISTS bus_client (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255),
+    status INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS bus_provider (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    contact VARCHAR(255),
+    status INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS bus_quote (
+    id SERIAL PRIMARY KEY,
+    client_id INTEGER NOT NULL REFERENCES bus_client(id),
+    description VARCHAR(255),
+    total NUMERIC(10,2),
+    status INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS bus_purchase (
+    id SERIAL PRIMARY KEY,
+    provider_id INTEGER NOT NULL REFERENCES bus_provider(id),
+    description VARCHAR(255),
+    total NUMERIC(10,2),
+    status INTEGER NOT NULL
+);


### PR DESCRIPTION
## Summary
- add new business entities: Client, Provider, Quote, Purchase
- create DTOs and CRUD services/controllers
- provide JPA repositories
- add Flyway migration for new tables
- insert default modules for new features

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687451ac02ac8332ad1c671b6ed5120e