### PR TITLE
feat: add pagination to list endpoints

### DIFF
--- a/src/main/java/com/ferrisys/controller/AuthRestController.java
+++ b/src/main/java/com/ferrisys/controller/AuthRestController.java
@@ -4,6 +4,7 @@ import com.ferrisys.common.dto.ModuleDTO;
 import com.ferrisys.service.UserService;
 import com.ferrisys.common.dto.AuthResponse;
 import com.ferrisys.common.dto.LoginRequest;
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.dto.RegisterRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -13,7 +14,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
-import java.util.List;
 
 @RestController
 @RequestMapping("/v1/auth")
@@ -48,8 +48,10 @@ public class AuthRestController {
 
     @PostMapping("/modules")
     @ResponseStatus(HttpStatus.OK)
-    public List<ModuleDTO> getUserModules() {
-        return userService.getModulesForCurrentUser();
+    public PageResponse<ModuleDTO> getUserModules(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return userService.getModulesForCurrentUser(page, size);
     }
 
 }

--- a/src/main/java/com/ferrisys/controller/ClientController.java
+++ b/src/main/java/com/ferrisys/controller/ClientController.java
@@ -1,11 +1,11 @@
 package com.ferrisys.controller;
 
 import com.ferrisys.common.dto.ClientDTO;
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.service.business.ClientService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -26,7 +26,9 @@ public class ClientController {
     }
 
     @GetMapping("/list")
-    public List<ClientDTO> list() {
-        return clientService.list();
+    public PageResponse<ClientDTO> list(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return clientService.list(page, size);
     }
 }

--- a/src/main/java/com/ferrisys/controller/ModuleController.java
+++ b/src/main/java/com/ferrisys/controller/ModuleController.java
@@ -1,11 +1,11 @@
 package com.ferrisys.controller;
 
 import com.ferrisys.common.dto.ModuleDTO;
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.service.impl.ModuleServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -21,8 +21,10 @@ public class ModuleController {
     }
 
     @GetMapping("/list")
-    public List<ModuleDTO> getAll() {
-        return moduleService.getAll();
+    public PageResponse<ModuleDTO> getAll(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return moduleService.getAll(page, size);
     }
 
     @PostMapping("/disable")

--- a/src/main/java/com/ferrisys/controller/ProviderController.java
+++ b/src/main/java/com/ferrisys/controller/ProviderController.java
@@ -1,11 +1,11 @@
 package com.ferrisys.controller;
 
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.dto.ProviderDTO;
 import com.ferrisys.service.business.ProviderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -26,7 +26,9 @@ public class ProviderController {
     }
 
     @GetMapping("/list")
-    public List<ProviderDTO> list() {
-        return providerService.list();
+    public PageResponse<ProviderDTO> list(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return providerService.list(page, size);
     }
 }

--- a/src/main/java/com/ferrisys/controller/PurchaseController.java
+++ b/src/main/java/com/ferrisys/controller/PurchaseController.java
@@ -1,11 +1,11 @@
 package com.ferrisys.controller;
 
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.dto.PurchaseDTO;
 import com.ferrisys.service.business.PurchaseService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -26,7 +26,9 @@ public class PurchaseController {
     }
 
     @GetMapping("/list")
-    public List<PurchaseDTO> list() {
-        return purchaseService.list();
+    public PageResponse<PurchaseDTO> list(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return purchaseService.list(page, size);
     }
 }

--- a/src/main/java/com/ferrisys/controller/QuoteController.java
+++ b/src/main/java/com/ferrisys/controller/QuoteController.java
@@ -1,11 +1,11 @@
 package com.ferrisys.controller;
 
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.dto.QuoteDTO;
 import com.ferrisys.service.business.QuoteService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
 
@@ -27,7 +27,9 @@ public class QuoteController {
     }
 
     @GetMapping("/list")
-    public List<QuoteDTO> list() {
-        return quoteService.list();
+    public PageResponse<QuoteDTO> list(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return quoteService.list(page, size);
     }
 }

--- a/src/main/java/com/ferrisys/controller/RoleController.java
+++ b/src/main/java/com/ferrisys/controller/RoleController.java
@@ -1,5 +1,6 @@
 package com.ferrisys.controller;
 
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.dto.RoleDTO;
 import com.ferrisys.service.impl.RoleServiceImpl;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -27,8 +27,10 @@ public class RoleController {
     }
 
     @PostMapping("/list")
-    public List<RoleDTO> listRoles() {
-        return roleService.getAll();
+    public PageResponse<RoleDTO> listRoles(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return roleService.getAll(page, size);
     }
 
     @PostMapping("/disable")

--- a/src/main/java/com/ferrisys/repository/RoleModuleRepository.java
+++ b/src/main/java/com/ferrisys/repository/RoleModuleRepository.java
@@ -3,15 +3,15 @@ package com.ferrisys.repository;
 import com.ferrisys.common.entity.user.AuthModule;
 import com.ferrisys.common.entity.user.AuthRoleModule;
 import com.ferrisys.common.entity.user.Role;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import java.util.UUID;
-
-import java.util.List;
 
 public interface RoleModuleRepository extends JpaRepository<AuthRoleModule, UUID> {
     void deleteByRole(Role role);
 
     @Query("SELECT rm.module FROM AuthRoleModule rm WHERE rm.role.id = :roleId AND rm.status = 1")
-    List<AuthModule> findModulesByRoleId(UUID roleId);
+    Page<AuthModule> findModulesByRoleId(UUID roleId, Pageable pageable);
 }

--- a/src/main/java/com/ferrisys/service/UserService.java
+++ b/src/main/java/com/ferrisys/service/UserService.java
@@ -2,11 +2,11 @@ package com.ferrisys.service;
 
 import com.ferrisys.common.dto.AuthResponse;
 import com.ferrisys.common.dto.ModuleDTO;
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.dto.RegisterRequest;
 import com.ferrisys.common.entity.user.AuthUserRole;
 import com.ferrisys.common.entity.user.User;
 
-import java.util.List;
 import java.util.UUID;
 
 public interface UserService {
@@ -27,6 +27,6 @@ public interface UserService {
 
     AuthResponse recoverPassword(String newPassword, String confirmPassword, String userToken);
 
-    List<ModuleDTO> getModulesForCurrentUser();
+    PageResponse<ModuleDTO> getModulesForCurrentUser(int page, int size);
 
 }

--- a/src/main/java/com/ferrisys/service/business/ClientService.java
+++ b/src/main/java/com/ferrisys/service/business/ClientService.java
@@ -1,12 +1,12 @@
 package com.ferrisys.service.business;
 
 import com.ferrisys.common.dto.ClientDTO;
+import com.ferrisys.common.dto.PageResponse;
 
-import java.util.List;
 import java.util.UUID;
 
 public interface ClientService {
     void saveOrUpdate(ClientDTO dto);
     void disable(UUID id);
-    List<ClientDTO> list();
+    PageResponse<ClientDTO> list(int page, int size);
 }

--- a/src/main/java/com/ferrisys/service/business/ProviderService.java
+++ b/src/main/java/com/ferrisys/service/business/ProviderService.java
@@ -1,12 +1,12 @@
 package com.ferrisys.service.business;
 
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.dto.ProviderDTO;
 
-import java.util.List;
 import java.util.UUID;
 
 public interface ProviderService {
     void saveOrUpdate(ProviderDTO dto);
     void disable(UUID id);
-    List<ProviderDTO> list();
+    PageResponse<ProviderDTO> list(int page, int size);
 }

--- a/src/main/java/com/ferrisys/service/business/PurchaseService.java
+++ b/src/main/java/com/ferrisys/service/business/PurchaseService.java
@@ -1,12 +1,12 @@
 package com.ferrisys.service.business;
 
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.dto.PurchaseDTO;
 
-import java.util.List;
 import java.util.UUID;
 
 public interface PurchaseService {
     void saveOrUpdate(PurchaseDTO dto);
     void disable(UUID id);
-    List<PurchaseDTO> list();
+    PageResponse<PurchaseDTO> list(int page, int size);
 }

--- a/src/main/java/com/ferrisys/service/business/QuoteService.java
+++ b/src/main/java/com/ferrisys/service/business/QuoteService.java
@@ -1,12 +1,12 @@
 package com.ferrisys.service.business;
 
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.dto.QuoteDTO;
 
-import java.util.List;
 import java.util.UUID;
 
 public interface QuoteService {
     void saveOrUpdate(QuoteDTO dto);
     void disable(UUID id);
-    List<QuoteDTO> list();
+    PageResponse<QuoteDTO> list(int page, int size);
 }

--- a/src/main/java/com/ferrisys/service/business/impl/ClientServiceImpl.java
+++ b/src/main/java/com/ferrisys/service/business/impl/ClientServiceImpl.java
@@ -1,12 +1,15 @@
 package com.ferrisys.service.business.impl;
 
 import com.ferrisys.common.dto.ClientDTO;
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.entity.business.Client;
 import com.ferrisys.repository.ClientRepository;
 import com.ferrisys.service.business.ClientService;
 import java.util.UUID;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -41,8 +44,9 @@ public class ClientServiceImpl implements ClientService {
     }
 
     @Override
-    public List<ClientDTO> list() {
-        return clientRepository.findAll().stream()
+    public PageResponse<ClientDTO> list(int page, int size) {
+        Page<Client> result = clientRepository.findAll(PageRequest.of(page, size));
+        List<ClientDTO> content = result.getContent().stream()
                 .map(c -> ClientDTO.builder()
                         .id(c.getId())
                         .name(c.getName())
@@ -52,5 +56,7 @@ public class ClientServiceImpl implements ClientService {
                         .status(c.getStatus())
                         .build())
                 .toList();
+        return new PageResponse<>(content, result.getTotalPages(), result.getTotalElements(),
+                result.getNumber(), result.getSize());
     }
 }

--- a/src/main/java/com/ferrisys/service/business/impl/ProviderServiceImpl.java
+++ b/src/main/java/com/ferrisys/service/business/impl/ProviderServiceImpl.java
@@ -1,5 +1,6 @@
 package com.ferrisys.service.business.impl;
 
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.dto.ProviderDTO;
 import com.ferrisys.common.entity.business.Provider;
 import com.ferrisys.repository.ProviderRepository;
@@ -7,6 +8,8 @@ import com.ferrisys.service.business.ProviderService;
 import java.util.UUID;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -42,8 +45,9 @@ public class ProviderServiceImpl implements ProviderService {
     }
 
     @Override
-    public List<ProviderDTO> list() {
-        return providerRepository.findAll().stream()
+    public PageResponse<ProviderDTO> list(int page, int size) {
+        Page<Provider> result = providerRepository.findAll(PageRequest.of(page, size));
+        List<ProviderDTO> content = result.getContent().stream()
                 .map(p -> ProviderDTO.builder()
                         .id(p.getId())
                         .name(p.getName())
@@ -54,5 +58,7 @@ public class ProviderServiceImpl implements ProviderService {
                         .status(p.getStatus())
                         .build())
                 .toList();
+        return new PageResponse<>(content, result.getTotalPages(), result.getTotalElements(),
+                result.getNumber(), result.getSize());
     }
 }

--- a/src/main/java/com/ferrisys/service/business/impl/PurchaseServiceImpl.java
+++ b/src/main/java/com/ferrisys/service/business/impl/PurchaseServiceImpl.java
@@ -1,5 +1,6 @@
 package com.ferrisys.service.business.impl;
 
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.dto.PurchaseDTO;
 import com.ferrisys.common.dto.PurchaseDetailDTO;
 import com.ferrisys.common.entity.business.Provider;
@@ -14,6 +15,8 @@ import com.ferrisys.service.business.PurchaseService;
 import java.util.UUID;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -69,8 +72,9 @@ public class PurchaseServiceImpl implements PurchaseService {
     }
 
     @Override
-    public List<PurchaseDTO> list() {
-        return purchaseRepository.findAll().stream()
+    public PageResponse<PurchaseDTO> list(int page, int size) {
+        Page<Purchase> result = purchaseRepository.findAll(PageRequest.of(page, size));
+        List<PurchaseDTO> content = result.getContent().stream()
                 .map(p -> PurchaseDTO.builder()
                         .id(p.getId())
                         .providerId(p.getProvider().getId())
@@ -87,5 +91,7 @@ public class PurchaseServiceImpl implements PurchaseService {
                         .status(p.getStatus())
                         .build())
                 .toList();
+        return new PageResponse<>(content, result.getTotalPages(), result.getTotalElements(),
+                result.getNumber(), result.getSize());
     }
 }

--- a/src/main/java/com/ferrisys/service/business/impl/QuoteServiceImpl.java
+++ b/src/main/java/com/ferrisys/service/business/impl/QuoteServiceImpl.java
@@ -1,5 +1,6 @@
 package com.ferrisys.service.business.impl;
 
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.dto.QuoteDTO;
 import com.ferrisys.common.dto.QuoteDetailDTO;
 import com.ferrisys.common.entity.business.Client;
@@ -14,6 +15,8 @@ import com.ferrisys.service.business.QuoteService;
 import java.util.UUID;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -68,8 +71,9 @@ public class QuoteServiceImpl implements QuoteService {
     }
 
     @Override
-    public List<QuoteDTO> list() {
-        return quoteRepository.findAll().stream()
+    public PageResponse<QuoteDTO> list(int page, int size) {
+        Page<Quote> result = quoteRepository.findAll(PageRequest.of(page, size));
+        List<QuoteDTO> content = result.getContent().stream()
                 .map(q -> QuoteDTO.builder()
                         .id(q.getId())
                         .clientId(q.getClient().getId())
@@ -86,5 +90,7 @@ public class QuoteServiceImpl implements QuoteService {
                         .status(q.getStatus())
                         .build())
                 .toList();
+        return new PageResponse<>(content, result.getTotalPages(), result.getTotalElements(),
+                result.getNumber(), result.getSize());
     }
 }

--- a/src/main/java/com/ferrisys/service/impl/ModuleServiceImpl.java
+++ b/src/main/java/com/ferrisys/service/impl/ModuleServiceImpl.java
@@ -1,10 +1,13 @@
 package com.ferrisys.service.impl;
 
 import com.ferrisys.common.dto.ModuleDTO;
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.entity.user.AuthModule;
 import com.ferrisys.repository.ModuleRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import java.util.UUID;
 
@@ -36,8 +39,9 @@ public class ModuleServiceImpl {
         moduleRepository.save(module);
     }
 
-    public List<ModuleDTO> getAll() {
-        return moduleRepository.findAll().stream()
+    public PageResponse<ModuleDTO> getAll(int page, int size) {
+        Page<AuthModule> result = moduleRepository.findAll(PageRequest.of(page, size));
+        List<ModuleDTO> content = result.getContent().stream()
                 .map(m -> ModuleDTO.builder()
                         .id(m.getId())
                         .name(m.getName())
@@ -45,6 +49,8 @@ public class ModuleServiceImpl {
                         .status(m.getStatus())
                         .build())
                 .toList();
+        return new PageResponse<>(content, result.getTotalPages(), result.getTotalElements(),
+                result.getNumber(), result.getSize());
     }
 
     public void disableModule(UUID id) {

--- a/src/main/java/com/ferrisys/service/impl/RoleServiceImpl.java
+++ b/src/main/java/com/ferrisys/service/impl/RoleServiceImpl.java
@@ -1,5 +1,6 @@
 package com.ferrisys.service.impl;
 
+import com.ferrisys.common.dto.PageResponse;
 import com.ferrisys.common.dto.RoleDTO;
 import com.ferrisys.common.entity.user.AuthModule;
 import com.ferrisys.common.entity.user.AuthRoleModule;
@@ -9,6 +10,8 @@ import com.ferrisys.repository.RoleModuleRepository;
 import com.ferrisys.repository.RoleRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import java.util.UUID;
 
@@ -56,8 +59,9 @@ public class RoleServiceImpl {
         }
     }
 
-    public List<RoleDTO> getAll() {
-        return roleRepository.findAll().stream()
+    public PageResponse<RoleDTO> getAll(int page, int size) {
+        Page<Role> result = roleRepository.findAll(PageRequest.of(page, size));
+        List<RoleDTO> content = result.getContent().stream()
                 .map(role -> RoleDTO.builder()
                         .id(role.getId())
                         .name(role.getName())
@@ -65,6 +69,8 @@ public class RoleServiceImpl {
                         .status(role.getStatus())
                         .build())
                 .toList();
+        return new PageResponse<>(content, result.getTotalPages(), result.getTotalElements(),
+                result.getNumber(), result.getSize());
     }
 
     @Transactional


### PR DESCRIPTION
## Summary
- paginate module retrieval for current user
- apply PageResponse-based pagination to list endpoints in business controllers
- support pageable module lookups in role-module repository

## Testing
- `mvn -q -e test` *(fails: missing dependency versions)*

------
https://chatgpt.com/codex/tasks/task_e_68900e146fb08332815f9598b7bbfeae